### PR TITLE
34 Fix dynamic page titles

### DIFF
--- a/components/common/layout.tsx
+++ b/components/common/layout.tsx
@@ -3,11 +3,11 @@ import Head from 'next/head';
 import Navbar from './navbar/navbar';
 
 interface LayoutProps {
-    pageName: string;
+    pageTitle: string;
 }
 
-const Layout: FC<LayoutProps> = ({ children, pageName }) => {
-    const title = `Jerry's ${pageName}`;
+const Layout: FC<LayoutProps> = ({ children, pageTitle }) => {
+    const title = `Jerry's ${pageTitle}`;
 
     return <>
         <Head>

--- a/components/common/navbar/navbar.scss
+++ b/components/common/navbar/navbar.scss
@@ -1,6 +1,6 @@
 .navbar {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
     padding: 1rem;
 
     &__link {

--- a/components/resume/resume.tsx
+++ b/components/resume/resume.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import Layout from '../common/layout';
 import Job from './job/job';
 import Skills from './skills/skills';
 import { Basics, Job as IJob } from './types';
@@ -10,34 +11,36 @@ interface ResumeProps {
 }
 
 const Resume: FC<ResumeProps> = ({ basics, skills, jobs }) => {
-    return <div className="resume">
-        <div className="resume__contact-info">
-            <h1>{basics.name}</h1>
-            <div className="resume__contact-info__basics">
-                <div>
-                    <strong>Email </strong>
-                    <a href={`mailto:${basics.email}`}>
-                        {basics.email}
-                    </a>
-                </div>
-                <div>
-                    <strong>Github </strong>
-                    <a href={basics.url} target="_blank" rel="noreferrer">
-                        {basics.url.replace('https://', '')}
-                    </a>
+    return <Layout pageTitle="Resume">
+        <div className="resume">
+            <div className="resume__contact-info">
+                <h1>{basics.name}</h1>
+                <div className="resume__contact-info__basics">
+                    <div>
+                        <strong>Email </strong>
+                        <a href={`mailto:${basics.email}`}>
+                            {basics.email}
+                        </a>
+                    </div>
+                    <div>
+                        <strong>Github </strong>
+                        <a href={basics.url} target="_blank" rel="noreferrer">
+                            {basics.url.replace('https://', '')}
+                        </a>
+                    </div>
                 </div>
             </div>
+            <div>
+                {basics.summary}
+            </div>
+            <h2>Skills</h2>
+            <div>
+                <Skills skills={skills} />
+            </div>
+            <h2>Professional Experience</h2>
+            {jobs.map(job => <Job {...job} key={job.companyName} />)}
         </div>
-        <div>
-            {basics.summary}
-        </div>
-        <h2>Skills</h2>
-        <div>
-            <Skills skills={skills} />
-        </div>
-        <h2>Professional Experience</h2>
-        {jobs.map(job => <Job {...job} key={job.companyName} />)}
-    </div>;
+    </Layout>;
 };
 
 export default Resume;

--- a/data/resume/resume.json
+++ b/data/resume/resume.json
@@ -16,7 +16,7 @@
       "startDate": "2021-08-01",
       "highlights": [
         "Built functional React components (utilizing hooks when appropriate), elevated common state and async handling to redux reducers, and extracted components as sensible patterns of usage emerged.",
-        "Utilize Grubhub’s component library for common cases to solve design needs, maintain consistency of user experience, and speed up development. For situational needs, have leveraged SCSS or Styled Components.",
+        "Utilize Grubhub's component library for common cases to solve design needs, maintain consistency of user experience, and speed up development. For situational needs, have leveraged SCSS or Styled Components.",
         "Wrote unit, integration, and E2E tests, balancing coverage, confidence, level of effort, and maintenance costs.",
         "Championed good programming practices by writing clear/maintainable code, thorough code reviews, balancing development speed vs tech debt, and participating in architecture discussions.",
         "Adept at ramping up on unfamiliar codebases and domains, making meaningful contributions, after tackling projects across the Restaurant, Delivery, Customer Support, Corporate Client, and Diner portions of the Grubhub business.",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import '../styles/globals.scss';
 import type { AppProps } from 'next/app';
-import Layout from '../components/common/layout';
 
 function MyApp({ Component, pageProps }: AppProps) {
-    return <Layout pageName={Component.name}>
-        <Component {...pageProps} />
-    </Layout>;
+    return <Component {...pageProps} />;
 }
 
 export default MyApp;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import type { NextPage } from 'next';
+import Layout from '../components/common/layout';
 
 const Home: NextPage = () => {
-    return (
+    return <Layout pageTitle="Home">
         <div className="home">
             <h1>Home</h1>
             <p className="home__intro">
@@ -37,7 +38,7 @@ const Home: NextPage = () => {
 
 
         </div>
-    );
+    </Layout>;
 };
 
 export default Home;


### PR DESCRIPTION
# Summary
Refactors the approach used to set dynamic page titles.

# Background
Prior approach used the page component name to set the page title, which broke once app is deployed since part of the code minification process changes the component name property. This lead to page titles which looked like

![image](https://user-images.githubusercontent.com/667983/187047976-8fcb8b17-aaa1-41de-84c4-bea3d2c376cb.png)

This refactored approach results in 
![image](https://user-images.githubusercontent.com/667983/187047990-af99f6d2-6224-44be-835f-5f2bec50e5ec.png)


# Checklist

- [x] Added Screenshots
- [x] PR linked to issue
